### PR TITLE
Add generic state changed event.

### DIFF
--- a/src/ssm.js
+++ b/src/ssm.js
@@ -46,7 +46,8 @@
     };
 
     var browserResize = function (localBrowserWidth) {
-        var totalStates = states.length,
+        var changed = false,
+            totalStates = states.length,
             totalConfigOptions = configOptions.length,
             leaveMethods = [],
             resizeMethods = [],
@@ -87,11 +88,14 @@
                     currentStates.push(states[i]);
                     enterMethods = enterMethods.concat(states[i].onEnter);
                 }
+
+                changed = true;
             }
             else{
                 if(objectInArray(currentStates, states[i])){
                     leaveMethods = leaveMethods.concat(states[i].onLeave);
                     currentStates = removeObjectInArray(currentStates,states[i]);
+                    changed = true;
                 }
             }
         }
@@ -100,7 +104,13 @@
         fireAllMethodsInArray(leaveMethods);
         fireAllMethodsInArray(enterMethods);
         fireAllMethodsInArray(resizeMethods);
+
+        if (changed) {
+            ssm.onStateChange();
+        }
     };
+
+    ssm.onStateChange = function() {};
 
     ssm.browserResize = browserResize;
 

--- a/test/index.html
+++ b/test/index.html
@@ -187,6 +187,26 @@
 
                 ok(ssm.getConfigOption().length === configOptions, "Passed Removing Config Option");
             });
+
+            test("General state change hook", function() {
+                var changed = false;
+
+                ssm.onStateChange = function() {
+                    changed = true;
+                };
+
+                ssm.addState(
+                    {
+                        id: 'desktop',
+                        onEnter: function(){}
+                    }
+                );
+                
+                ssm.browserResize(800);
+                ssm.removeAllStates();
+
+                ok(changed == true, "Fired after resize.");
+            });
         </script>
     </body>
 </html>


### PR DESCRIPTION
There are some third party plugins (like image slideshows for example) that have a `.refresh()` method that needs to be called whenever there's a change.

This is basically to prevent having to call said `.refresh()` method multiple times within each state's `onXX` methods.